### PR TITLE
Add "Categories" key to zotero.desktop

### DIFF
--- a/build-repo
+++ b/build-repo
@@ -203,6 +203,7 @@ class Package:
     desktop.set('Desktop Entry', 'Exec', f'/usr/lib/{self.package}/{self.package} --url %u')
     desktop.set('Desktop Entry', 'Icon', f'/usr/lib/{self.package}/chrome/icons/default/default48.png')
     desktop.set('Desktop Entry', 'Type', 'Application')
+    desktop.set('Desktop Entry', 'Categories', 'Office;Education;Literature')
     desktop.set('Desktop Entry', 'StartupNotify', 'true')
     desktop.set('Desktop Entry', 'MimeType', ';'.join([
       'x-scheme-handler/zotero',


### PR DESCRIPTION
FWIW:

- JabRef, [as packaged by ArchLinux](https://aur.archlinux.org/cgit/aur.git/tree/jabref.desktop?h=jabref), has `Categories=Office` ;
- Mendeley has `Categories=Education;Literature;Qt` ;
- legacy `zotero.desktop` has  `Categories=Office`.