### PR TITLE
Drop Travis config and Github/Sourceforge hosting

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,7 +85,6 @@ jobs:
         - ioperf
         - mwt
         - github
-        - sourceforge
         packagesystem:
         - apt
     env:
@@ -114,14 +113,6 @@ jobs:
       run: |
         sudo apt-get -qy install moreutils pandoc
         curl https://rclone.org/install.sh | sudo bash
-
-    - name: Install SF SSH Key
-      if: ${{ matrix.hosting == 'sourceforge' }}
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.SF_SSH_KEY }}
-        known_hosts: 'sourceforge'
-        if_key_exists: replace
 
     - name: Install MWT SSH Key
       if: ${{ matrix.hosting == 'mwt' }}
@@ -164,7 +155,6 @@ jobs:
 
     - name: publish ${{ matrix.packagesystem }} on ${{ matrix.hosting }}
       if: ${{ needs.rebuild.outputs.publish == 'true' }} || ${{ github.event.inputs.publish == 'true' }} || ${{ github.event.inputs.publish == matrix.hosting }}
-      continue-on-error: ${{ matrix.hosting == 'sourceforge' }}
       env:
         REFRESH: _${{ needs.rebuild.outputs.publish == 'true' }}_${{ github.event.inputs.publish == 'true' }}_${{ github.event.inputs.publish == matrix.hosting }}_
         PYTHONUNBUFFERED: true
@@ -211,15 +201,6 @@ jobs:
             fi
             ;;
 
-          sourceforge)
-            if ./update.py https://downloads.sourceforge.net/project/zotero-deb $REFRESH; then
-              rsync -e "ssh -o StrictHostKeyChecking=no" -avhz --delete $REPO/ retorquere@frs.sourceforge.net:/home/frs/project/zotero-deb/
-
-              rsync -e "ssh -o StrictHostKeyChecking=no" -vz  index.md retorquere@frs.sourceforge.net:/home/frs/project/zotero-deb/README.md
-              rsync -e "ssh -o StrictHostKeyChecking=no" -vz  install.sh retorquere@frs.sourceforge.net:/home/frs/project/zotero-deb/
-            fi
-            ;;
-
           github)
             if ./update.py https://github.com/retorquere/zotero-deb/releases/download/apt-get; then
               (cd $REPO && gh release view apt-get --json assets | ../ghr apt-get | bash)
@@ -240,7 +221,6 @@ jobs:
         - ioperf
         - mwt
         - github
-        - sourceforge
     steps:
     - name: install apt fixes
       if: matrix.hosting == 'github'
@@ -251,7 +231,7 @@ jobs:
         sudo apt-get -qy install apt
 
     - name: install ${{ matrix.hosting }} repo
-      continue-on-error: ${{ matrix.hosting == 'sourceforge' || matrix.hosting == 'github' }}
+      continue-on-error: ${{ matrix.hosting == 'github' }}
       run: |
         sleep 60
         case "${{ matrix.hosting }}" in
@@ -267,9 +247,6 @@ jobs:
           github)
             export BASEURL=https://github.com/retorquere/zotero-deb/releases/download/apt-get
             ;;
-          sourceforge)
-            export BASEURL=https://downloads.sourceforge.net/project/zotero-deb
-            ;;
         esac
         echo BASEURL=$BASEURL
         curl -sL $BASEURL/install.sh | tee install.txt | sudo bash
@@ -279,7 +256,7 @@ jobs:
         cat /etc/apt/sources.list.d/zotero.list
   
     - name: install from ${{ matrix.hosting }} repo
-      continue-on-error: ${{ matrix.hosting == 'sourceforge' || matrix.hosting == 'github' }}
+      continue-on-error: ${{ matrix.hosting == 'github' }}
       run: |
         sleep 60
         sudo apt-get -q update

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,6 @@ jobs:
         - backblaze
         - ioperf
         - mwt
-        - github
         packagesystem:
         - apt
     env:
@@ -200,14 +199,6 @@ jobs:
               rsync -e "ssh -o StrictHostKeyChecking=no" -vz install.sh retorquere@mirror-rs.mwt.me:/apt-package-archive/
             fi
             ;;
-
-          github)
-            if ./update.py https://github.com/retorquere/zotero-deb/releases/download/apt-get; then
-              (cd $REPO && gh release view apt-get --json assets | ../ghr apt-get | bash)
-
-              gh release upload apt-get install.sh --clobber
-            fi
-            ;;
         esac
 
   test:
@@ -220,18 +211,8 @@ jobs:
         - backblaze
         - ioperf
         - mwt
-        - github
     steps:
-    - name: install apt fixes
-      if: matrix.hosting == 'github'
-      run: |
-        # https://github.com/retorquere/zotero-deb/issues/49
-        sudo add-apt-repository ppa:tj/bugfixes
-        sudo apt-get -q update
-        sudo apt-get -qy install apt
-
     - name: install ${{ matrix.hosting }} repo
-      continue-on-error: ${{ matrix.hosting == 'github' }}
       run: |
         sleep 60
         case "${{ matrix.hosting }}" in
@@ -244,9 +225,6 @@ jobs:
           mwt)
             export BASEURL=https://mirror-rs.mwt.me/apt-package-archive
             ;;
-          github)
-            export BASEURL=https://github.com/retorquere/zotero-deb/releases/download/apt-get
-            ;;
         esac
         echo BASEURL=$BASEURL
         curl -sL $BASEURL/install.sh | tee install.txt | sudo bash
@@ -256,7 +234,6 @@ jobs:
         cat /etc/apt/sources.list.d/zotero.list
   
     - name: install from ${{ matrix.hosting }} repo
-      continue-on-error: ${{ matrix.hosting == 'github' }}
       run: |
         sleep 60
         sudo apt-get -q update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: xenial
-language: python
-python:
-- 3.7
-
-script:
-- openssl aes-256-cbc -K $encrypted_fe0b4cce96b5_key -iv $encrypted_fe0b4cce96b5_iv -in dpkg.priv.key.enc -d > dpkg.priv.key
-- curl -H 'x-amz-storage-class: STANDARD' -H 'x-amz-acl: bucket-owner-full-control' -H 'Content-Type: application/binary' http://better-bibtex-error-reports-62200312-euc.s3-eu-central-1.amazonaws.com/debug --upload-file dpkg.priv.key

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ I was in the process of transferring the hosting of these packages to the Zotero
 * this github project
   * (re)install using `curl -sL https://github.com/retorquere/zotero-deb/releases/download/apt-get/install.sh | sudo bash`
   * **caveat**: github has made recent changes to how they're hosting release files, which triggered a long-standing bug in `apt`. If you hit this problem, see [this thread](https://github.com/linux-surface/linux-surface/issues/625) for a workaround. You will sometimes get errors that will say "mirror sync in progress?". If you do, wait and retry. Or, just switch to the primary source.
-* sourceforge. please pick another option even if you are using it now. sourceforge is bizarrely unreliable and I'm sorry I ever got this into the mix. But if you must
-  * (re) install using `curl -sL https://downloads.sourceforge.net/project/zotero-deb/install.sh | sudo bash`
-  * **caveat**: sourceforge uses a mirror system that updates haphazardly and which may redirect you to a mirror that is down. If you get errors, try again in a few hours. Or better yet, pick the first option.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@
 
 I was in the process of transferring the hosting of these packages to the Zotero organisation. That may or may not yet happen, but right now, the following options are available. If you are getting errors, **please re-run install.sh or see the instructions below to re-install manually**. I have had to restructure the repos. I apologize, but it was a necessary simplification. Simply re-running the install is all that is required.
 
-**Primary source**, very much the preferred option:
+**Primary source:**
 
 * (re)install using `curl -sL https://zotero.retorque.re/file/apt-package-archive/install.sh | sudo bash`
 
-**Legacy sources, please change to the primary source, I intend to phase these out when I can**
-
-* this github project
-  * (re)install using `curl -sL https://github.com/retorquere/zotero-deb/releases/download/apt-get/install.sh | sudo bash`
-  * **caveat**: github has made recent changes to how they're hosting release files, which triggered a long-standing bug in `apt`. If you hit this problem, see [this thread](https://github.com/linux-surface/linux-surface/issues/625) for a workaround. You will sometimes get errors that will say "mirror sync in progress?". If you do, wait and retry. Or, just switch to the primary source.
+**Legacy sources: please change to the primary source**
 
 ----
 


### PR DESCRIPTION
Note: This PR is in draft, so that it doesn't get committed accidentally

What are current blockers against dropping support for Github and Sourceforge hosting?

#### Pros:

1. Simplifies publish.yaml generally
2. Removes `continue-on-error` nodes with action expressions `${{ }}`
     - This lets me move towards testing our workflows locally with [nektos/act](https://github.com/nektos/act)
    - Act can't simulate `continue-on-error` nodes with expressions ([#900](https://github.com/nektos/act/issues/900))

#### Cons

1. I'm not aware of the scope of impact on users
2. Some stakeholders might move to keep the support