### PR TITLE
Local E2E Test for rebuild.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ release
 repo
 send.sh
 staging
+test_apt
+test/resource/gpg
 zotero
 *.deb
 *.jar

--- a/apt.py
+++ b/apt.py
@@ -137,8 +137,8 @@ def mkrepo():
     run('rm -rf by-hash')
     run('bzip2 -kf Packages')
     run('apt-ftparchive -o APT::FTPArchive::AlwaysStat="true" -o APT::FTPArchive::Release::Codename=./ -o APT::FTPArchive::Release::Acquire-By-Hash="yes" release . > Release')
-    run('gpg --yes -abs -u dpkg -o Release.gpg --digest-algo sha256 Release')
-    run('gpg --yes -abs -u dpkg --clearsign -o InRelease --digest-algo sha256 Release')
+    run(f'gpg --yes -abs --local-user {Config.maintainer.gpgkey} -o Release.gpg --digest-algo sha256 Release')
+    run(f'gpg --yes -abs --local-user {Config.maintainer.gpgkey} --clearsign -o InRelease --digest-algo sha256 Release')
 
     for hsh in ['MD5Sum', 'SHA1', 'SHA256', 'SHA512']:
       run(f'mkdir -p by-hash/{hsh}')

--- a/test/resource/e2e_test_config.yml
+++ b/test/resource/e2e_test_config.yml
@@ -1,0 +1,20 @@
+maintainer:
+  email: test_maintainer
+  gpgkey: test_key
+zotero:
+  description: Zotero is a free, easy-to-use tool to help you collect, organize, cite, and share research
+  dependencies:
+    - gnupg
+  bump:
+    5.0.96.2: 3
+    5.0.96.3: 3
+    5.0.97.57+07df7d0de: 3
+jurism:
+  description: Juris-M is a free, easy-to-use tool to help you collect, organize, cite, and share research
+  dependencies:
+    - gnupg
+    - default-jre
+    - libreoffice-java-common
+  bump:
+    5.0.93m18: 3
+staging: staging

--- a/test/test_e2e_rebuild.sh
+++ b/test/test_e2e_rebuild.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e # Halt on errors
+
+# Test a full rebuild
+# Will reuse staged data to reduce bandwidth
+# Set the CLEAN_STAGING env var to start from scratch
+
+CONFIG=test/resource/e2e_test_config.yml
+MODE=apt
+REPO=test_apt
+
+GNUPGHOME=test/resource/gpg
+GNUPGHOME="$(realpath $GNUPGHOME)" # We need a full path for apt.py:mkrepo
+GPGKEY=test_key
+
+export GNUPGHOME
+export REPO
+
+# Cleanup previous tests
+rm -rf "$GNUPGHOME"
+rm -rf $REPO
+[[ -n $CLEAN_STAGING ]] && rm -rf staging
+
+# Build temporary gpg key
+mkdir "$GNUPGHOME"
+gpg \
+  --yes \
+  --batch \
+  --passphrase '' \
+  --quick-gen-key $GPGKEY
+
+# Perform a rebuild
+python rebuild.py \
+  --config $CONFIG \
+  --mode $MODE
+
+# Test package signatures
+dpkg-sig --verify $REPO/*.deb

--- a/util.py
+++ b/util.py
@@ -12,6 +12,7 @@ yaml=YAML(typ='safe')
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--mode')
+parser.add_argument('--config')
 args, unknownargs = parser.parse_known_args()
 sys.argv = sys.argv[:1]
 sys.argv += unknownargs
@@ -41,7 +42,9 @@ def bumped(client, version):
     return version
 
 ## load config
-with open('config.yml') as f:
+config_file = args.config or 'config.yml'
+
+with open(config_file) as f:
   Config = json.loads(json.dumps(yaml.load(f)), object_hook=Munch.fromDict)
   Config.mode = args.mode
   assert Config.mode in [ None, 'apt'], Config.mode


### PR DESCRIPTION
## E2E testing of the rebuild process

Validate the rebuild process locally after refactoring or feature work.

Also adds a `--config` flag to `rebuild.py`.

## New Files

- `test`: directory for tests
- `test/test_e2e_rebuild.sh`: e2e test for rebuild.py
- `test/resource`: test resource directory (config files, key material, etc) 
- `test/resource/e2e_test_config.yml`: config for e2e test
- `test/resource/gpg`: ephemeral key material for test release signing
- `test_apt`: repo folder for the test

## Running Test

```
./test/test_e2e_rebuild.sh
```

**Note:** We cache staging files to reduce server bandwidth on subsequent runs. To clear staging before test:

```
CLEAN_STAGING=1 ./test/test_e2e_rebuild.sh
```

## Test Procedure

1. Clear the repo folder and perform a full rebuild. Use a disposable gpg key to sign packages
2.  Test package signatures after rebuild

This ensures we can rebuild without errors and have signed the packages correctly.

**Note:** This does *not* yet ensure we can install the packages. Ideas are welcome.


## Additional feature: --config flag

We can now pass a custom config yaml to `rebuild.py` with the `--config` flag:

```bash
rebuild.py --mode apt  --config myConfig.yml 
```