### PR TITLE
Setup external mirror and allow installer to work for any url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ I was in the process of transferring the hosting of these packages to the Zotero
 
 * (re)install using `curl -sL https://raw.githubusercontent.com/retorquere/zotero-deb/master/install.sh | sudo bash`
 
-**Mirrors:**:
+**Mirrors:**
 
 * https://zotero-deb.mirror.ioperf.eu/
+* https://mirror.mwt.me/zotero/deb
 
 **Deprecated sources, please change to the primary source.**
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ esac
 
 export GNUPGHOME="/dev/null"
 
+REPO=${1:-'https://zotero.retorque.re/file/apt-package-archive'}
 KEYNAME=zotero-archive-keyring.gpg
 GPGKEY=https://raw.githubusercontent.com/retorquere/zotero-deb/master/$KEYNAME
 KEYRING=/usr/share/keyrings/$KEYNAME
@@ -28,7 +29,7 @@ sudo chmod 644 $KEYRING
 sudo rm -f /etc/apt/trusted.gpg.d/zotero.gpg
 
 cat << EOF | sudo tee /etc/apt/sources.list.d/zotero.list
-deb [signed-by=$KEYRING by-hash=force] https://zotero.retorque.re/file/apt-package-archive ./
+deb [signed-by=$KEYRING by-hash=force] $REPO ./
 EOF
 
 sudo apt-get clean


### PR DESCRIPTION
Since you're using B2, I've setup https://mirror.mwt.me/zotero to just pull from that every six hours. This way it's there in the background if you find it useful, but it can't get in your way.

I edited the install script to allow the user to *optionally* specify a mirror. If nothing is specified, then it uses the default mirror. However, it's now possible to specify with something like

```sh
curl -sL https://raw.githubusercontent.com/mwt/zotero-deb/master/install.sh | sudo bash /dev/stdin "https://mirror.mwt.me/zotero/deb"
```

The behavior of the existing commands in the readme remain unchanged.

I've left https://zotero.mwt.me as it was. So, this will continue to work as it did before. If you feel like using it, you can.