### PR TITLE
chore(ci): bump dependent actions to use node20

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,13 +23,13 @@ jobs:
     # runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.11.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -66,9 +66,9 @@ jobs:
         EOF
 
     - name: Cache repo
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
-        cache-name: v3
+        cache-name: v4
       with:
         path: ${{ env.REPO }}
         key: repo-${{ env.cache-name }}-${{ github.sha }}-${{ hashFiles('zotero-releases.json', 'jurism-releases.json') }}
@@ -153,9 +153,9 @@ jobs:
         curl -L 'https://github.com/Juris-M/assets/releases/download/client%2Freleases%2Fincrementals-linux/incrementals-release-linux' -o jurism-releases.json
 
     - name: Cache repo
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
-        cache-name: v3
+        cache-name: v4
       with:
         path: ${{ env.REPO }}
         key: repo-${{ env.cache-name }}-${{ github.sha }}-${{ hashFiles('zotero-releases.json', 'jurism-releases.json') }}


### PR DESCRIPTION
There is a warning message about the deprecation of Node.js 16: https://github.com/retorquere/zotero-deb/actions/runs/8180864880. Bump the dependent actions to use node20.