### PR TITLE
chore(ci): replace `cancel-workflow-action` action with native `concurrency` property

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,16 +15,15 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rebuild:
     runs-on: ubuntu-latest
     # runs-on: ubuntu-20.04
     steps:
-    - name: cancel previous runs
-      uses: styfle/cancel-workflow-action@0.12.1
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v4
 
     #- uses: crystal-lang/install-crystal@v1
@@ -125,4 +124,3 @@ jobs:
           echo validate $c.desktop
           desktop-file-validate /usr/share/applications/$c.desktop && echo 'all clear!'
         done
-


### PR DESCRIPTION
As the note shown in [cancel-workflow-action](https://github.com/styfle/cancel-workflow-action?tab=readme-ov-file). The custom action `cancel-workflow-action` can be replaced with the native `concurrency` property.

As the workflow will only be triggered by `schedule` or `workflow_dispatch`. The [value of `github.ref`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) should be `refs/heads/<branch_name>`. We can simply using the configuration listed in [this example](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).
