### PR TITLE
Fix deb822-style format

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ cat << EOF | sudo tee $SOURCES
 Types: deb
 URIs: $REPO
 Suites: ./
-Options: by-hash=force
+By-Hash: force
 Signed-By:$GPGKEY
 EOF
 


### PR DESCRIPTION
According to: <https://manpages.debian.org/apt/sources.list.5.en.html#THE_DEB_AND_DEB-SRC_TYPES:_GENERAL_FORMAT>

Unsupported `Options` option is "silently ignored by all APT versions".