### PR TITLE
harden: sanitize child_process call in nix.js...

### DIFF
--- a/nix.js
+++ b/nix.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { writeFileSync, readFileSync, existsSync, appendFileSync } from 'fs'
 import yaml from 'js-yaml'
 import $stringify from 'json-stringify-deterministic'
@@ -30,8 +30,7 @@ class Release {
     else {
       console.log('  fetching hash for', this.url)
       const name = `zotero-${channel}-${version.replace(/\+/g, '.')}-${arch}.tar.xz`
-      const cmd = `nix --extra-experimental-features "nix-command flakes" store prefetch-file --json --name '${name}' '${this.url}'`
-      const result = execSync(cmd, { encoding: 'utf8' })
+      const result = execFileSync('nix', ['--extra-experimental-features', 'nix-command flakes', 'store', 'prefetch-file', '--json', '--name', name, this.url], { encoding: 'utf8' })
       const { hash } = JSON.parse(result)
       this.hash = hash
     }


### PR DESCRIPTION
## Summary
Harden input handling in `nix.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `nix.js:34` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `arch`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `nix.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
